### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ mcache
 Install through  [composer](https://getcomposer.org/) package manager.
 Find it on [packagist](https://packagist.org/packages/g4/mcache).
 
-    require: "g4/mcache": "*"
+```sh
+composer require g4/mcache
+```
 
 ## Supported caching systems
 


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
